### PR TITLE
Introduce Ecto-style API

### DIFF
--- a/examples/db_agent/lib/db_agent.ex
+++ b/examples/db_agent/lib/db_agent.ex
@@ -12,22 +12,19 @@ defmodule DBAgent do
   @spec get(DBConnection.conn, ((state :: any) -> value), timeout) ::
     value when value: var
   def get(conn, fun, timeout \\ 5_000) when is_function(fun, 1) do
-    DBConnection.query!(conn, {:get, fun},
-      [queue_timeout: timeout, prepare: :manual, decode: :manual])
+    DBConnection.query!(conn, :get, [fun], [queue_timeout: timeout])
   end
 
   @spec update(DBConnection.conn, ((state :: any) -> new_state :: any), timeout) ::
     :ok
   def update(conn, fun, timeout \\ 5_000) when is_function(fun, 1) do
-    DBConnection.query!(conn, {:update, fun},
-      [queue_timeout: timeout, prepare: :manual, decode: :manual])
+    DBConnection.query!(conn, :update, [fun], [queue_timeout: timeout])
   end
 
   @spec get(DBConnection.conn, ((state :: any) -> {value, new_state :: any}), timeout) ::
     value when value: var
   def get_and_update(conn, fun, timeout \\ 5_000) when is_function(fun, 2) do
-    DBConnection.query!(conn, {:get_and_update, fun},
-      [queue_timeout: timeout, prepare: :manual, decode: :manual])
+    DBConnection.query!(conn, :get_and_update, [fun], [queue_timeout: timeout])
   end
 
   @spec transaction(DBConnection.conn, ((DBConnection.t) -> res),  timeout) ::
@@ -50,13 +47,13 @@ defmodule DBAgent do
 
   def checkin(s), do: {:ok, s}
 
-  def handle_execute({:get, fun}, _, %{state: state} = s) do
+  def handle_execute(:get, [fun], _, %{state: state} = s) do
     {:ok, fun.(state), s}
   end
-  def handle_execute({:update, fun}, _, %{state: state} = s) do
+  def handle_execute(:update, [fun], _, %{state: state} = s) do
     {:ok, :ok, %{s | state: fun.(state)}}
   end
-  def handle_execute({:get_and_update, fun}, _, %{state: state} = s) do
+  def handle_execute(:get_and_update, [fun], _, %{state: state} = s) do
     {res, state} = fun.(state)
     {:ok, res, %{s | state: state}}
   end

--- a/integration_test/cases/client_test.exs
+++ b/integration_test/cases/client_test.exs
@@ -87,18 +87,18 @@ defmodule ClientTest do
 
     assert P.run(pool, fn(conn) ->
         :timer.sleep(50)
-        assert {:error, %RuntimeError{}} = P.execute(conn, %Q{})
+        assert {:error, %RuntimeError{}} = P.execute(conn, %Q{}, [:param])
         :result
     end, [timeout: 0])  == {:ok, :result}
 
-    assert P.execute(pool, %Q{}) == {:ok, %R{}}
+    assert P.execute(pool, %Q{}, [:param]) == {:ok, %R{}}
 
     assert [
       {:connect, _},
       {:disconnect, _},
       {:connect, _},
-      {:handle_execute, [%Q{}, _, :state]},
-      {:handle_execute, [%Q{}, _, :new_state]}] = A.record(agent)
+      {:handle_execute, [%Q{}, [:param], _, :state]},
+      {:handle_execute, [%Q{}, [:param], _, :new_state]}] = A.record(agent)
   end
 
   test "reconnect when client timeout and then crashes" do
@@ -109,7 +109,7 @@ defmodule ClientTest do
         send(opts[:runner], :reconnected)
         {:ok, :new_state}
       end,
-      fn(_, _, _) ->
+      fn(_, _, _, _) ->
         throw(:oops)
       end,
       {:ok, %R{}, :newer_state}]
@@ -130,20 +130,20 @@ defmodule ClientTest do
     try do
       P.run(pool, fn(conn) ->
         :timer.sleep(50)
-        P.execute(conn, %Q{})
+        P.execute(conn, %Q{}, [:param])
       end, [timeout: 0])
     catch
       :throw, :oops ->
         :ok
     end
 
-    assert P.execute(pool, %Q{}) == {:ok, %R{}}
+    assert P.execute(pool, %Q{}, [:param]) == {:ok, %R{}}
 
     assert [
       {:connect, _},
       {:disconnect, _},
       {:connect, _},
-      {:handle_execute, [%Q{}, _, :state]},
-      {:handle_execute, [%Q{}, _, :new_state]}] = A.record(agent)
+      {:handle_execute, [%Q{}, [:param], _, :state]},
+      {:handle_execute, [%Q{}, [:param], _, :new_state]}] = A.record(agent)
   end
 end

--- a/lib/db_connection/query.ex
+++ b/lib/db_connection/query.ex
@@ -36,12 +36,12 @@ defprotocol DBConnection.Query do
 
   See `DBConnection.execute/3`.
   """
-  @spec encode(any, Keyword.t) :: any
-  def encode(query, opts)
+  @spec encode(any, [any], Keyword.t) :: any
+  def encode(query, params, opts)
 end
 
 defimpl DBConnection.Query, for: Any do
   def parse(query, _), do: query
   def describe(query, _), do: query
-  def encode(query, _), do: query
+  def encode(_, params, _), do: params
 end

--- a/test/db_connection_test.exs
+++ b/test/db_connection_test.exs
@@ -35,12 +35,12 @@ defmodule DBConnectionTest do
 
       assert Sample.handle_prepare(:query, [], :state) == {:ok, :query, :state}
 
-      assert_raise RuntimeError, "handle_execute/3 not implemented",
-        fn() -> Sample.handle_execute(:query, [], :state) end
+      assert_raise RuntimeError, "handle_execute/4 not implemented",
+        fn() -> Sample.handle_execute(:query, [], [], :state) end
 
       # not a bug! handle_execute forwards to handle_query/3
-      assert_raise RuntimeError, "handle_execute/3 not implemented",
-        fn() -> Sample.handle_execute_close(:query, [], :state) end
+      assert_raise RuntimeError, "handle_execute/4 not implemented",
+        fn() -> Sample.handle_execute_close(:query, [], [], :state) end
 
       assert Sample.handle_close(:query, [], :state) == {:ok, :state}
 
@@ -55,10 +55,10 @@ defmodule DBConnectionTest do
     defmodule SampleEC do
       use DBConnection
 
-      def handle_execute({:ok, _}, _, state) do
+      def handle_execute({:ok, _}, _, _, state) do
         {:ok, :ok, [:execute | state]}
       end
-      def handle_execute({error, _}, _, state)
+      def handle_execute({error, _}, _, _, state)
       when error in [:error, :disconnect] do
         {error, %ArgumentError{message: "execute"}, [:execute | state]}
       end
@@ -73,25 +73,25 @@ defmodule DBConnectionTest do
     end
 
     try do
-      assert SampleEC.handle_execute_close({:ok, :ok}, [], []) ==
+      assert SampleEC.handle_execute_close({:ok, :ok}, [], [], []) ==
         {:ok, :ok, [:close, :execute]}
 
-      assert SampleEC.handle_execute_close({:ok, :error}, [], []) ==
+      assert SampleEC.handle_execute_close({:ok, :error}, [], [], []) ==
         {:error, %ArgumentError{message: "close"}, [:close, :execute]}
 
-      assert SampleEC.handle_execute_close({:ok, :disconnect}, [], []) ==
+      assert SampleEC.handle_execute_close({:ok, :disconnect}, [], [], []) ==
         {:disconnect, %ArgumentError{message: "close"}, [:close, :execute]}
 
-      assert SampleEC.handle_execute_close({:error, :ok}, [], []) ==
+      assert SampleEC.handle_execute_close({:error, :ok}, [], [], []) ==
         {:error, %ArgumentError{message: "execute"}, [:close, :execute]}
 
-      assert SampleEC.handle_execute_close({:error, :error}, [], []) ==
+      assert SampleEC.handle_execute_close({:error, :error}, [], [], []) ==
         {:error, %ArgumentError{message: "close"}, [:close, :execute]}
 
-      assert SampleEC.handle_execute_close({:error, :disconnect}, [], []) ==
+      assert SampleEC.handle_execute_close({:error, :disconnect}, [], [], []) ==
         {:disconnect, %ArgumentError{message: "close"}, [:close, :execute]}
 
-      assert SampleEC.handle_execute_close({:disconnect, nil}, [], []) ==
+      assert SampleEC.handle_execute_close({:disconnect, nil}, [], [], []) ==
         {:disconnect, %ArgumentError{message: "execute"}, [:execute]}
     after
       :code.purge(SampleEC)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -8,12 +8,12 @@ defmodule TestConnection do
         TestConnection.start_link(unquote(opts) ++ opts2)
       end
 
-      def query(pool, query, opts2 \\ []) do
-        DBConnection.query(pool, query, opts2 ++ unquote(opts))
+      def query(pool, query, params, opts2 \\ []) do
+        DBConnection.query(pool, query, params, opts2 ++ unquote(opts))
       end
 
-      def query!(pool, query, opts2 \\ []) do
-        DBConnection.query!(pool, query, opts2 ++ unquote(opts))
+      def query!(pool, query, params, opts2 \\ []) do
+        DBConnection.query!(pool, query, params, opts2 ++ unquote(opts))
       end
 
       def run(pool, fun, opts2 \\ []) do
@@ -34,12 +34,12 @@ defmodule TestConnection do
         DBConnection.prepare!(pool, query, opts2 ++ unquote(opts))
       end
 
-      def execute(pool, query, opts2 \\ []) do
-        DBConnection.execute(pool, query, opts2 ++ unquote(opts))
+      def execute(pool, query, params, opts2 \\ []) do
+        DBConnection.execute(pool, query, params, opts2 ++ unquote(opts))
       end
 
-      def execute!(pool, query, opts2 \\ []) do
-        DBConnection.execute!(pool, query, opts2 ++ unquote(opts))
+      def execute!(pool, query, params, opts2 \\ []) do
+        DBConnection.execute!(pool, query, params, opts2 ++ unquote(opts))
       end
 
       def close(pool, query, opts2 \\ []) do
@@ -94,12 +94,12 @@ defmodule TestConnection do
     TestAgent.eval(:handle_prepare, [query, opts, state])
   end
 
-  def handle_execute(query, opts, state) do
-    TestAgent.eval(:handle_execute, [query, opts, state])
+  def handle_execute(query, params, opts, state) do
+    TestAgent.eval(:handle_execute, [query, params, opts, state])
   end
 
-  def handle_execute_close(query, opts, state) do
-    TestAgent.eval(:handle_execute_close, [query, opts, state])
+  def handle_execute_close(query, params, opts, state) do
+    TestAgent.eval(:handle_execute_close, [query, params, opts, state])
   end
 
   def handle_close(query, opts, state) do
@@ -131,9 +131,9 @@ defimpl DBConnection.Query, for: TestQuery do
     describe.(query)
   end
 
-  def encode(query, opts) do
+  def encode(_, params, opts) do
     encode = Keyword.get(opts, :encode, &(&1))
-    encode.(query)
+    encode.(params)
   end
 end
 


### PR DESCRIPTION
Firstly we provide a mechanism to re-use prepared queries on multiple connections in the same pool. This means that Ecto (or another library) can use its owns global cache of prepared queries with a pool and if a query has not been prepared on the checked out connection it can be prepared and executed.

A naive driver can use this mechanism by trying to execute the query and return `{:prepare, state}` when the database says the query is not prepared. A driver could handle its own cache per connection if it proved beneficial.

Secondly we move query parameters outside of the query term so that it is easier to combine prepared queries and executed parameters.

This means that Ecto (or another library) can do the equivalent of:

```elixir
{pool, opts} = repo.__pool__
case repo.fetch_query(key) do
  {:ok, query} ->
    DBConnection.execute(pool, query, params, opts)
  :error ->
    query = DBConnection.prepare!(pool, query, opts)
    repo.put_query(key, query)
    DBConnection.execute!(pool, query, params, opts)
end
```

Ecto also requires #2 and perhaps other changes.