### PR TITLE
Introduce DBConnection.Sandbox

### DIFF
--- a/integration_test/cases/backoff_test.exs
+++ b/integration_test/cases/backoff_test.exs
@@ -24,8 +24,10 @@ defmodule BackoffTest do
     assert_receive {:hi, ^conn}
 
     assert [
-      connect: [[_, _ | ^opts]],
-      connect: [[_, _ | ^opts]]] = A.record(agent)
+      connect: [opts2],
+      connect: [opts2]] = A.record(agent)
+
+    assert :lists.suffix(opts, opts2)
   end
 
   test "backoff after disconnect and failed connection attempt" do
@@ -52,11 +54,13 @@ defmodule BackoffTest do
     assert_receive {:hi2, ^conn}
 
     assert [
-      connect: [[_, _ | ^opts]],
+      connect: [opts2],
       handle_info: [:hello, :state],
       disconnect: [^err, :discon],
-      connect: [[_, _ | ^opts]],
-      connect: [[_, _ | ^opts]]] = A.record(agent)
+      connect: [opts2],
+      connect: [opts2]] = A.record(agent)
+
+    assert :lists.suffix(opts, opts2)
   end
 
   test "backoff :stop exits on failed initial connection attempt" do
@@ -76,7 +80,9 @@ defmodule BackoffTest do
     assert_receive {:error, conn}
     assert_receive {:EXIT, ^conn, {^err, _}}
 
-    assert [{:connect, [[_, _ | ^opts]]} | _] = A.record(agent)
+    assert [{:connect, [opts2]} | _] = A.record(agent)
+
+    assert :lists.suffix(opts, opts2)
   end
 
   test "backoff :stop exits after disconnect without attempting to connect" do
@@ -99,8 +105,10 @@ defmodule BackoffTest do
     assert_receive {:EXIT, ^conn, {^err, _}}
 
     assert [
-      {:connect, [[_, _ | ^opts]]},
+      {:connect, [opts2]},
       {:handle_info, [:hello, :state]} | _] = A.record(agent)
+
+    assert :lists.suffix(opts, opts2)
   end
 
   test "backoff after failed after_connect" do
@@ -126,8 +134,10 @@ defmodule BackoffTest do
     assert_receive :after_connect, 500
 
     assert [
-      {:connect, [_]},
+      {:connect, [opts2]},
       {:disconnect, [%DBConnection.Error{}, :state]},
-      {:connect, [_]} | _] = A.record(agent)
+      {:connect, [opts2]} | _] = A.record(agent)
+
+    assert :lists.suffix(opts, opts2)
   end
 end

--- a/integration_test/cases/sandbox_test.exs
+++ b/integration_test/cases/sandbox_test.exs
@@ -1,0 +1,325 @@
+defmodule SandboxTest do
+  use ExUnit.Case, async: true
+
+  alias TestPool, as: P
+  alias TestAgent, as: A
+
+  test "start, restart and stop sandbox" do
+    stack = [
+      {:ok, :state},
+      {:ok, :new_state},
+      {:ok, :newer_state},
+      {:ok, :newest_state}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self()]
+    {:ok, pool} = P.sandbox_link(opts)
+
+    assert P.start_sandbox(pool) == :ok
+    assert P.restart_sandbox(pool) == :ok
+    assert P.stop_sandbox(pool) == :ok
+
+     assert [
+      connect: _,
+      sandbox_start: [_, :state],
+      sandbox_restart: [_, :new_state],
+      sandbox_stop: [_, :newer_state]] = A.record(agent)
+  end
+
+  test "start raises if already started" do
+    stack = [
+      {:ok, :state},
+      {:ok, :new_state}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self()]
+    {:ok, pool} = P.sandbox_link(opts)
+
+    assert P.start_sandbox(pool) == :ok
+
+    assert_raise RuntimeError, "sandbox already started",
+      fn() -> P.start_sandbox(pool) end
+
+     assert [
+      connect: _,
+      sandbox_start: [_, :state]] = A.record(agent)
+  end
+
+  test "restart raises if not started" do
+    stack = [
+      {:ok, :state}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self()]
+    {:ok, pool} = P.sandbox_link(opts)
+
+    assert_raise RuntimeError, "sandbox not started",
+      fn() -> P.restart_sandbox(pool) end
+
+     assert [connect: _] = A.record(agent)
+  end
+
+  test "stop does not raise if not started" do
+    stack = [
+      {:ok, :state}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self()]
+    {:ok, pool} = P.sandbox_link(opts)
+
+    assert P.stop_sandbox(pool) == :ok
+
+     assert [connect: _] = A.record(agent)
+  end
+
+  test "sandboxed transaction commits" do
+    stack = [
+      {:ok, :state},
+      {:ok, :new_state},
+      {:ok, :newer_state},
+      {:ok, :newest_state}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self()]
+    {:ok, pool} = P.sandbox_link(opts)
+
+    assert P.start_sandbox(pool) == :ok
+    assert P.transaction(pool, fn(_) -> :hi end) == {:ok, :hi}
+
+    assert [
+      connect: _,
+      sandbox_start: [_, :state],
+      sandbox_begin: [_, :new_state],
+      sandbox_commit: [_, :newer_state]] = A.record(agent)
+  end
+
+  test "sandboxed transaction rollsback" do
+    stack = [
+      {:ok, :state},
+      {:ok, :new_state},
+      {:ok, :newer_state},
+      {:ok, :newest_state}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self()]
+    {:ok, pool} = P.sandbox_link(opts)
+
+    assert P.start_sandbox(pool) == :ok
+    assert P.transaction(pool,
+        fn(conn) -> P.rollback(conn, :hi) end) == {:error, :hi}
+
+    assert [
+      connect: _,
+      sandbox_start: [_, :state],
+      sandbox_begin: [_, :new_state],
+      sandbox_rollback: [_, :newer_state]] = A.record(agent)
+  end
+
+  test "transaction after sandbox" do
+    stack = [
+      {:ok, :state},
+      {:ok, :new_state},
+      {:ok, :newer_state},
+      {:ok, :newest_state},
+      {:ok, :state2}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self()]
+    {:ok, pool} = P.sandbox_link(opts)
+
+    assert P.start_sandbox(pool) == :ok
+    assert P.stop_sandbox(pool) == :ok
+    assert P.transaction(pool, fn(_) -> :hi end) == {:ok, :hi}
+
+    assert [
+      connect: _,
+      sandbox_start: [_, :state],
+      sandbox_stop: [_, :new_state],
+      handle_begin: [_, :newer_state],
+      handle_commit: [_, :newest_state]] = A.record(agent)
+  end
+
+  test "start raises inside transaction" do
+    stack = [
+      {:ok, :state},
+      {:ok, :new_state},
+      {:ok, :newer_state}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self()]
+    {:ok, pool} = P.sandbox_link(opts)
+
+    assert P.transaction(pool, fn(conn) ->
+      assert_raise RuntimeError, "can not start sandbox inside transaction",
+        fn() -> P.start_sandbox(conn) end
+      :hi
+    end) == {:ok, :hi}
+
+     assert [
+      connect: _,
+      handle_begin: [_, :state],
+      handle_commit: [_, :new_state]] = A.record(agent)
+  end
+
+  test "stop and restart raise inside transaction" do
+    stack = [
+      {:ok, :state},
+      {:ok, :new_state},
+      {:ok, :newer_state},
+      {:ok, :newest_state}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self()]
+    {:ok, pool} = P.sandbox_link(opts)
+
+    assert P.start_sandbox(pool)
+    assert P.transaction(pool, fn(conn) ->
+      assert_raise RuntimeError, "can not restart sandbox inside transaction",
+        fn() -> P.restart_sandbox(conn) end
+
+      assert_raise RuntimeError, "can not stop sandbox inside transaction",
+        fn() -> P.stop_sandbox(conn) end
+
+      :hi
+    end) == {:ok, :hi}
+
+     assert [
+      connect: _,
+      sandbox_start: [_, :state],
+      sandbox_begin: [_, :new_state],
+      sandbox_commit: [_, :newer_state]] = A.record(agent)
+  end
+
+  test "sandbox transaction begin error raises but still sandbox" do
+    stack = [
+      {:ok, :state},
+      {:ok, :new_state},
+      {:error, RuntimeError.exception("oops"), :newer_state},
+      {:ok, :newest_state},
+      {:ok, :newest_state2}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self()]
+    {:ok, pool} = P.sandbox_link(opts)
+
+    assert P.start_sandbox(pool) == :ok
+
+    assert_raise RuntimeError, "oops",
+      fn() -> P.transaction(pool, fn(_) -> flunk("transaction ran") end) end
+
+    assert P.transaction(pool, fn(_) -> :hi end) == {:ok, :hi}
+
+
+    assert [
+      connect: _,
+      sandbox_start: [_, :state],
+      sandbox_begin: [_, :new_state],
+      sandbox_begin: [_, :newer_state],
+      sandbox_commit: [_, :newest_state]] = A.record(agent)
+  end
+
+  test "sandbox transaction commit error raises but still sandbox" do
+    stack = [
+      {:ok, :state},
+      {:ok, :new_state},
+      {:ok, :newer_state},
+      {:error, RuntimeError.exception("oops"), :newest_state},
+      {:ok, :newest_state2},
+      {:ok, :newest_state3}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self()]
+    {:ok, pool} = P.sandbox_link(opts)
+
+    assert P.start_sandbox(pool) == :ok
+
+    assert_raise RuntimeError, "oops",
+      fn() -> P.transaction(pool, fn(_) -> end) end
+
+    assert P.transaction(pool, fn(_) -> :hi end) == {:ok, :hi}
+
+    assert [
+      connect: _,
+      sandbox_start: [_, :state],
+      sandbox_begin: [_, :new_state],
+      sandbox_commit: [_, :newer_state],
+      sandbox_begin: [_, :newest_state],
+      sandbox_commit: [_, :newest_state2]] = A.record(agent)
+  end
+
+  test "sandbox transaction rollback error raises but still sandbox" do
+    stack = [
+      {:ok, :state},
+      {:ok, :new_state},
+      {:ok, :newer_state},
+      {:error, RuntimeError.exception("oops"), :newest_state},
+      {:ok, :newest_state2},
+      {:ok, :newest_state3}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self()]
+    {:ok, pool} = P.sandbox_link(opts)
+
+    assert P.start_sandbox(pool) == :ok
+
+    assert_raise RuntimeError, "oops",
+      fn() -> P.transaction(pool, fn(conn) -> P.rollback(conn, :oops) end) end
+
+    assert P.transaction(pool, fn(_) -> :hi end) == {:ok, :hi}
+
+    assert [
+      connect: _,
+      sandbox_start: [_, :state],
+      sandbox_begin: [_, :new_state],
+      sandbox_rollback: [_, :newer_state],
+      sandbox_begin: [_, :newest_state],
+      sandbox_commit: [_, :newest_state2]] = A.record(agent)
+  end
+
+  test "sandbox transaction begin disconnect stops connection" do
+    err = RuntimeError.exception("oops")
+    stack = [
+      fn(opts) ->
+        send(opts[:parent], {:hi, self()})
+        Process.link(opts[:parent])
+        {:ok, :state}
+      end,
+      {:ok, :new_state},
+      {:disconnect, err, :newer_state},
+      :ok,
+      {:ok, :state2}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self()]
+    Process.flag(:trap_exit, true)
+    {:ok, pool} = P.sandbox_link(opts)
+
+    assert P.start_sandbox(pool) == :ok
+
+    assert_raise RuntimeError, "oops",
+      fn() -> P.transaction(pool, fn(_) -> flunk("transaction ran") end) end
+
+    assert_received {:hi, conn}
+
+    assert_receive {:EXIT, ^conn, {^err, [_|_]}}
+
+    assert [
+      {:connect, _},
+      {:sandbox_start, [_, :state]},
+      {:sandbox_begin, [_, :new_state]},
+      {:disconnect, [^err, :newer_state]} | _] = A.record(agent)
+  end
+end

--- a/integration_test/sojourn/test_helper.exs
+++ b/integration_test/sojourn/test_helper.exs
@@ -6,7 +6,15 @@ defmodule TestPool do
   use TestConnection, @opts
 
   def start_link(opts) do
-    {:ok, sup} = TestConnection.start_link(@opts ++ opts)
+    do_start(:start_link, opts)
+  end
+
+  def sandbox_link(opts) do
+    do_start(:sandbox_link, opts)
+  end
+
+  defp do_start(start, opts) do
+    {:ok, sup} = apply(TestConnection, start, [@opts ++ opts])
     children = Supervisor.which_children(sup)
     {_, broker, _, _} = List.keyfind(children, :sbroker, 0)
     {:ok, broker}

--- a/integration_test/tests.exs
+++ b/integration_test/tests.exs
@@ -9,5 +9,6 @@ Code.require_file "cases/query_test.exs", __DIR__
 Code.require_file "cases/queue_test.exs", __DIR__
 Code.require_file "cases/run_execute_test.exs", __DIR__
 Code.require_file "cases/run_transaction_test.exs", __DIR__
+Code.require_file "cases/sandbox_test.exs", __DIR__
 Code.require_file "cases/transaction_execute_test.exs", __DIR__
 Code.require_file "cases/transaction_test.exs", __DIR__

--- a/lib/db_connection/sandbox.ex
+++ b/lib/db_connection/sandbox.ex
@@ -1,0 +1,273 @@
+defmodule DBConnection.Sandbox do
+  @moduledoc """
+  A behaviour module for implementing a sandbox over a `DBConnection`
+  connection.
+
+  To sandbox a connection start `DBConnection` with module
+  `DBConnection.Sandbox` and add the option `sandbox_mod: module`, where
+  `module` is the module to sandbox. The module must implement both
+  the `DBConnection` and `DBConnection.Sandbox` behaviours.
+
+  `DBConnection.Sandbox` callbacks will be used in place of `DBConnection`
+  transaction callbacks when sandbox mode is active.
+  """
+
+  @behaviour DBConnection
+
+  defstruct [:request]
+
+  @doc """
+  Start the sandbox on the connection. Return `{:ok, state}` on sucess to
+  continue, `{:error, exception, state}` to abort sandbox mode and continue or
+  `{:disconnect, exception, state}` to abort sandbox mode and disconnect.
+
+  This callback is called in the client process.
+  """
+  @callback sandbox_start(opts :: Keyword.t, state :: any) ::
+    {:ok, new_state :: any} |
+    {:error | :disconnect, Exception.t, new_state :: any}
+
+  @doc """
+  Restart the sandbox on the connection. Return `{:ok, state}` on sucess to
+  continue, `{:error, exception, state}` to continue the sandbox mode or
+  `{:disconnect, exception, state}` to abort sandbox mode and disconnect.
+
+  This callback is called in the client process.
+  """
+  @callback sandbox_restart(opts :: Keyword.t, state :: any) ::
+    {:ok, new_state :: any} |
+    {:error | :disconnect, Exception.t, new_state :: any}
+
+  @doc """
+  Restart the sandbox on the connection. Return `{:ok, state}` on sucess to
+  continue, `{:error, exception, state}` to continue the sandbox mode or
+  `{:disconnect, exception, state}` to abort sandbox mode and disconnect.
+
+  This callback is called in the client process.
+  """
+  @callback sandbox_stop(opts :: Keyword.t, state :: any) ::
+    {:ok, new_state :: any} |
+    {:error | :disconnect, Exception.t, new_state :: any}
+
+  @doc """
+  Begin a transaction in sandbox mode. Return `{:ok, state}` to continue,
+  `{:error, exception, state}` to abort the transaction and continue or
+  `{:disconnect, exception, state}` to abort the transaction and disconnect.
+
+  This callback is called in the client process.
+  """
+  @callback sandbox_begin(opts :: Keyword.t, state :: any) ::
+    {:ok, new_state :: any} |
+    {:error | :disconnect, Exception.t, new_state :: any}
+
+  @doc """
+  Pseudo-commit a transaction in sandbox mode. Return `{:ok, state}` on success
+  and to continue, `{:error, exception, state}` to abort the transaction and
+  continue or `{:disconnect, exception, state}` to abort the transaction and
+  disconnect.
+
+  This callback is called in the client process.
+  """
+  @callback sandbox_commit(opts :: Keyword.t, state :: any) ::
+    {:ok, new_state :: any} |
+    {:error | :disconnect, Exception.t, new_state :: any}
+
+  @doc """
+  Rollback a transaction in sandbox mode. Return `{:ok, state}` on success
+  and to continue, `{:error, exception, state}` to abort the transaction
+  and continue or `{:disconnect, exception, state}` to abort the
+  transaction and disconnect.
+
+  A transaction will be rolled back if an exception occurs or
+  `rollback/2` is called.
+
+  This callback is called in the client process.
+  """
+  @callback sandbox_rollback(opts :: Keyword.t, state :: any) ::
+    {:ok, new_state :: any} |
+    {:error | :disconnect, Exception.t, new_state :: any}
+
+  @doc """
+  Start sandbox mode on a connection.
+
+  Will fail if sandbox mode is active or if inside a transaction.
+  """
+  @spec start_sandbox(DBConnection.conn, Keyword.t) :: :ok
+  def start_sandbox(pool, opts \\ []), do: request(pool, :start, opts)
+
+  @doc """
+  Restart sandbox mode on a connection.
+
+  Will fail if sandbox mode is not active or if inside a transaction.
+  """
+  @spec restart_sandbox(DBConnection.conn, Keyword.t) :: :ok
+  def restart_sandbox(pool, opts \\ []), do: request(pool, :restart, opts)
+
+  @doc """
+  Stop sandbox mode on a connection.
+
+  Will fail inside a transaction when sandbox mode is active.
+  """
+  @spec stop_sandbox(DBConnection.conn, Keyword.t) :: :ok
+  def stop_sandbox(pool, opts \\ []), do: request(pool, :stop, opts)
+
+  @doc false
+  def connect(opts) do
+    mod = Keyword.fetch!(opts, :sandbox_mod)
+    case apply(mod, :connect, [opts]) do
+      {:ok, mod_state}    -> {:ok, {mod, :run, mod_state}}
+      {:error, _} = error -> error
+    end
+  end
+
+  @doc false
+  def checkout(state), do: handle(state, :checkout, [], :no_result)
+
+  @doc false
+  def checkin(state), do: handle(state, :checkin, [], :no_result)
+
+  @doc false
+  def ping(state), do: handle(state, :ping, [], :no_result)
+
+  @doc false
+  def handle_begin(opts, {_, :run, _} = state) do
+    transaction_handle(state, :handle_begin, opts, :transaction)
+  end
+  def handle_begin(opts, {_, :sandbox, _} = state) do
+    transaction_handle(state, :sandbox_begin, opts, :sandbox_transaction)
+  end
+
+  @doc false
+  def handle_commit(opts, {_, :transaction, _} = state) do
+    transaction_handle(state, :handle_commit, opts, :run)
+  end
+  def handle_commit(opts, {_, :sandbox_transaction, _} = state) do
+    transaction_handle(state, :sandbox_commit, opts, :sandbox)
+  end
+
+  @doc false
+  def handle_rollback(opts, {_, :transaction, _} = state) do
+    transaction_handle(state, :handle_rollback, opts, :run)
+  end
+  def handle_rollback(opts, {_, :sandbox_transaction, _} = state) do
+    transaction_handle(state, :sandbox_rollback, opts, :sandbox)
+  end
+
+  @doc false
+  def handle_prepare(query, opts, state) do
+    handle(state, :handle_prepare, [query, opts], :result)
+  end
+
+  @doc false
+  def handle_execute(query, params, opts, state) do
+    handle(state, :handle_execute, [query, params, opts], :execute)
+  end
+
+  @doc false
+  def handle_execute_close(query, params, opts, state) do
+    handle(state, :handle_execute_close, [query, params, opts], :execute)
+  end
+
+  @doc false
+  def handle_close(%__MODULE__{request: request}, opts, state) do
+    handle_request(request, opts, state)
+  end
+  def handle_close(query, opts, state) do
+    handle(state, :handle_close, [query, opts], :no_result)
+  end
+
+  @doc false
+  def handle_info(msg, state) do
+    handle(state, :handle_info, [msg], :no_result)
+  end
+
+  @doc false
+  def disconnect(err, {mod, status, state}) do
+    :ok = apply(mod, :disconnect, [err, state])
+    if status in [:sandbox, :sandbox_transaction] do
+      raise err
+    else
+      :ok
+    end
+  end
+
+  ## Helpers
+
+  defp request(pool, request, opts) do
+    DBConnection.close!(pool, %__MODULE__{request: request}, opts)
+  end
+
+  defp handle({mod, status, state}, callback, args, return) do
+    case apply(mod, callback, args ++ [state]) do
+      {:ok, state} when return == :no_result ->
+        {:ok, {mod, status, state}}
+      {:ok, result, state} when return in [:result, :execute] ->
+        {:ok, result, {mod, status, state}}
+      {:prepare, state} when return == :execute ->
+        {:prepare, {mod, status, state}}
+      {error, err, state} when error in [:disconnect, :error] ->
+        {error, err, {mod, status, state}}
+      other ->
+        other
+    end
+  end
+
+  defp transaction_handle({mod, status, state}, callback, opts, new_status) do
+    case apply(mod, callback, [opts, state]) do
+      {:ok, state} ->
+        {:ok, {mod, new_status, state}}
+      {:error, err, state} when status in [:run, :transaction] ->
+        {:error, err, {mod, :run, state}}
+      {:error, err, state} when status in [:sandbox, :sandbox_transaction] ->
+        {:error, err, {mod, :sandbox, state}}
+      {:disconnect, err, state} ->
+        {:disconnect, err, {mod, status, state}}
+      other ->
+        other
+    end
+  end
+
+  defp handle_request(:start, opts, {_, :run, _} = state) do
+    sandbox_handle(state, :sandbox_start, opts, :sandbox)
+  end
+  defp handle_request(:start, _, {_, :transaction, _} = state) do
+    err = RuntimeError.exception("can not start sandbox inside transaction")
+    {:error, err, state}
+  end
+  defp handle_request(:start, _, state) do
+    err = RuntimeError.exception("sandbox already started")
+    {:error, err, state}
+  end
+  defp handle_request(:restart, opts, {_, :sandbox, _} = state) do
+    sandbox_handle(state, :sandbox_restart, opts, :sandbox)
+  end
+  defp handle_request(:restart, _, {_, :sandbox_transaction, _} = state) do
+    err = RuntimeError.exception("can not restart sandbox inside transaction")
+    {:error, err, state}
+  end
+  defp handle_request(:restart, _, state) do
+    err = RuntimeError.exception("sandbox not started")
+    {:error, err, state}
+  end
+  defp handle_request(:stop, opts, {_, :sandbox, _} = state) do
+    sandbox_handle(state, :sandbox_stop, opts, :run)
+  end
+  defp handle_request(:stop, _, {_, :sandbox_transaction, _} = state) do
+    err = RuntimeError.exception("can not stop sandbox inside transaction")
+    {:error, err, state}
+  end
+  defp handle_request(:stop, _, state) do
+    {:ok, state}
+  end
+
+  defp sandbox_handle({mod, status, state}, callback, opts, new_status) do
+    case apply(mod, callback, [opts, state]) do
+      {:ok, state} ->
+        {:ok, {mod, new_status, state}}
+      {error, err, state} when error in [:disconnect, :error] ->
+        {:disconnect, err, {mod, status, state}}
+      other ->
+        other
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -8,6 +8,10 @@ defmodule TestConnection do
         TestConnection.start_link(unquote(opts) ++ opts2)
       end
 
+      def sandbox_link(opts2) do
+        TestConnection.sandbox_link(unquote(opts) ++ opts2)
+      end
+
       def query(pool, query, params, opts2 \\ []) do
         DBConnection.query(pool, query, params, opts2 ++ unquote(opts))
       end
@@ -50,11 +54,28 @@ defmodule TestConnection do
         DBConnection.close!(pool, query, opts2 ++ unquote(opts))
       end
 
-      defoverridable [start_link: 1]
+      def start_sandbox(pool, opts2 \\ []) do
+        DBConnection.Sandbox.start_sandbox(pool, opts2 ++ unquote(opts))
+      end
+
+      def restart_sandbox(pool, opts2 \\ []) do
+        DBConnection.Sandbox.restart_sandbox(pool, opts2 ++ unquote(opts))
+      end
+
+      def stop_sandbox(pool, opts2 \\ []) do
+        DBConnection.Sandbox.stop_sandbox(pool, opts2 ++ unquote(opts))
+      end
+
+      defoverridable [start_link: 1, sandbox_link: 1]
     end
   end
 
   def start_link(opts), do: DBConnection.start_link(__MODULE__, opts)
+
+  def sandbox_link(opts) do
+    opts = [sandbox_mod: __MODULE__] ++ opts
+    DBConnection.start_link(DBConnection.Sandbox, opts)
+  end
 
   def connect(opts) do
     agent = Keyword.fetch!(opts, :agent)
@@ -109,8 +130,31 @@ defmodule TestConnection do
   def handle_info(msg, state) do
     TestAgent.eval(:handle_info, [msg, state])
   end
-end
 
+  def sandbox_start(opts, state) do
+    TestAgent.eval(:sandbox_start, [opts, state])
+  end
+
+  def sandbox_restart(opts, state) do
+    TestAgent.eval(:sandbox_restart, [opts, state])
+  end
+
+  def sandbox_stop(opts, state) do
+    TestAgent.eval(:sandbox_stop, [opts, state])
+  end
+
+  def sandbox_begin(opts, state) do
+    TestAgent.eval(:sandbox_begin, [opts, state])
+  end
+
+  def sandbox_commit(opts, state) do
+    TestAgent.eval(:sandbox_commit, [opts, state])
+  end
+
+  def sandbox_rollback(opts, state) do
+    TestAgent.eval(:sandbox_rollback, [opts, state])
+  end
+end
 
 defmodule TestQuery do
   defstruct []


### PR DESCRIPTION
`DBConnection.Sandbox` is equivalent to `Ecto.Adapters.SQL.Sandbox` though requires a different adapter API. A nice advantage of this implementation is that sandboxing does not change the pooling or transaction code and is a wrapper around a `DBConnection` module. It might be possible to combine it with an ownership based pool.