### PR TITLE
Introduce execute_many/3

### DIFF
--- a/integration_test/cases/execute_many_test.exs
+++ b/integration_test/cases/execute_many_test.exs
@@ -1,0 +1,311 @@
+defmodule ExecuteManyTest do
+  use ExUnit.Case, async: true
+
+  alias TestPool, as: P
+  alias TestAgent, as: A
+  alias TestQuery, as: Q
+  alias TestResult, as: R
+
+  test "execute_many returns result" do
+    stack = [
+      {:ok, :state},
+      {:ok, :began, :new_state},
+      {:ok, [%R{}], :newer_state},
+      {:ok, :committed, :newest_state},
+      {:ok, :began, :state2},
+      {:ok, [%R{}], :new_state2},
+      {:ok, :committed, :newer_state2}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self()]
+    {:ok, pool} = P.start_link(opts)
+    assert P.execute_many(pool, [{%Q{}, [:param], [key: :value]}]) ==
+      {:ok, [%R{}]}
+    assert P.execute_many(pool, [{%Q{}, [:param], []}], [key: :value]) ==
+      {:ok, [%R{}]}
+
+    assert [
+      connect: [_],
+      handle_begin: [_, :state],
+      handle_execute_many: [[{%Q{}, [:param], [key: :value]}], _, :new_state],
+      handle_commit: [_, :newer_state],
+      handle_begin: [[{:key, :value} | _], :newest_state],
+      handle_execute_many: [[{%Q{}, [:param], []}],
+        [{:key, :value} | _], :state2],
+      handle_commit: [[{:key, :value} | _], :new_state2]] = A.record(agent)
+  end
+
+  test "execute_many logs result" do
+    stack = [
+      {:ok, :state},
+      {:ok, :began, :new_state},
+      {:ok, [%R{}], :newer_state},
+      {:ok, :committed, :newest_state}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    parent = self()
+    opts = [agent: agent, parent: parent]
+    {:ok, pool} = P.start_link(opts)
+
+    log = &send(parent, &1)
+    assert P.execute_many(pool, [{%Q{}, [:param], []}], [log: log]) ==
+      {:ok, [%R{}]}
+
+    assert_received %DBConnection.LogEntry{} = entry
+    assert %{call: :transaction, query: :begin, params: nil,
+             result: {:ok, :began}} = entry
+    assert is_integer(entry.pool_time)
+    assert entry.pool_time >= 0
+    assert is_integer(entry.connection_time)
+    assert entry.connection_time >= 0
+    assert is_nil(entry.decode_time)
+
+    assert_received %DBConnection.LogEntry{} = entry
+    assert %{call: :execute_many, query: :batch, params: [{%Q{}, [:param], []}],
+             result: {:ok, [%R{}]}} = entry
+    assert is_nil(entry.pool_time)
+    assert is_integer(entry.connection_time)
+    assert entry.connection_time >= 0
+    assert is_integer(entry.decode_time)
+    assert entry.decode_time >= 0
+
+    assert_received %DBConnection.LogEntry{} = entry
+    assert %{call: :transaction, query: :commit, params: nil,
+             result: {:ok, :committed}} = entry
+    assert is_nil(entry.pool_time)
+    assert is_integer(entry.connection_time)
+    assert entry.connection_time >= 0
+    assert is_nil(entry.decode_time)
+
+    assert [
+      connect: [_],
+      handle_begin: [_, :state],
+      handle_execute_many: [[{%Q{}, [:param], []}], _, :new_state],
+      handle_commit: [_, :newer_state]] = A.record(agent)
+  end
+
+  test "execute_many error returns error" do
+    err = RuntimeError.exception("oops")
+    stack = [
+      {:ok, :state},
+      {:ok, :began, :new_state},
+      {:error, err, :newer_state},
+      {:ok, :rolledback, :newest_state}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self()]
+    {:ok, pool} = P.start_link(opts)
+
+    assert P.execute_many(pool, [{%Q{}, [:param], []}]) == {:error, err}
+
+    assert [
+      connect: [_],
+      handle_begin: [_, :state],
+      handle_execute_many: [[{%Q{}, [:param], []}], _, :new_state],
+      handle_rollback: [_, :newer_state]] = A.record(agent)
+  end
+
+  test "execute_many! error raises error" do
+    err = RuntimeError.exception("oops")
+    stack = [
+      {:ok, :state},
+      {:ok, :began, :new_state},
+      {:error, err, :newer_state},
+      {:ok, :rolledback, :newest_state}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self()]
+    {:ok, pool} = P.start_link(opts)
+
+    assert_raise RuntimeError, "oops",
+      fn() -> P.execute_many!(pool, [{%Q{}, [:param], []}]) end
+
+    assert [
+      connect: [_],
+      handle_begin: [_, :state],
+      handle_execute_many: [[{%Q{}, [:param], []}], _, :new_state],
+      handle_rollback: [_, :newer_state]] = A.record(agent)
+  end
+
+  test "execute_many logs error" do
+    err = RuntimeError.exception("oops")
+    stack = [
+      {:ok, :state},
+      {:ok, :began, :new_state},
+      {:error, err, :newer_state},
+      {:ok, :rolledback, :newest_state}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    parent = self()
+    opts = [agent: agent, parent: parent]
+    {:ok, pool} = P.start_link(opts)
+
+    log = &send(parent, &1)
+    assert P.execute_many(pool, [{%Q{}, [:param], []}], [log: log]) ==
+      {:error, err}
+
+    assert_received %DBConnection.LogEntry{} = entry
+    assert %{call: :transaction, query: :begin, params: nil,
+             result: {:ok, :began}} = entry
+
+    assert_received %DBConnection.LogEntry{} = entry
+    assert %{call: :execute_many, query: :batch, params: [{%Q{}, [:param], []}],
+             result: {:error, ^err}} = entry
+    assert is_nil(entry.decode_time)
+
+    assert_received %DBConnection.LogEntry{} = entry
+    assert %{call: :transaction, query: :rollback, params: nil,
+             result: {:ok, :rolledback}} = entry
+
+    assert [
+      connect: [_],
+      handle_begin: [_, :state],
+      handle_execute_many: [[{%Q{}, [:param], []}], _, :new_state],
+      handle_rollback: [_, :newer_state]] = A.record(agent)
+  end
+
+  test "execute_many disconnect returns error" do
+    err = RuntimeError.exception("oops")
+    stack = [
+      {:ok, :state},
+      {:ok, :began, :new_state},
+      {:disconnect, err, :newer_state},
+      :ok,
+      fn(opts) ->
+        send(opts[:parent], :reconnected)
+        {:ok, :state}
+      end
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    parent = self()
+    opts = [agent: agent, parent: parent]
+    {:ok, pool} = P.start_link(opts)
+
+    assert P.execute_many(pool, [{%Q{}, [:param], []}]) == {:error, err}
+
+    assert_receive :reconnected
+
+    assert [
+      connect: [opts2],
+      handle_begin: [_, :state],
+      handle_execute_many: [[{%Q{}, [:param], []}], _, :new_state],
+      disconnect: [^err, :newer_state],
+      connect: [opts2]] = A.record(agent)
+  end
+
+  test "execute_many disconnect logs error" do
+    err = RuntimeError.exception("oops")
+    stack = [
+      {:ok, :state},
+      {:ok, :began, :new_state},
+      {:disconnect, err, :newer_state},
+      :ok,
+      fn(opts) ->
+        send(opts[:parent], :reconnected)
+        {:ok, :state}
+      end
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    parent = self()
+    opts = [agent: agent, parent: parent]
+    {:ok, pool} = P.start_link(opts)
+
+    log = &send(parent, &1)
+    assert P.execute_many(pool, [{%Q{}, [:param], []}], [log: log]) ==
+      {:error, err}
+
+    assert_received %DBConnection.LogEntry{} = entry
+    assert %{call: :transaction, query: :begin, params: nil,
+             result: {:ok, :began}} = entry
+
+    assert_received %DBConnection.LogEntry{} = entry
+    assert %{call: :execute_many, query: :batch, params: [{%Q{}, [:param], []}],
+             result: {:error, ^err}} = entry
+    assert is_nil(entry.decode_time)
+
+    refute_received %DBConnection.LogEntry{} = entry
+
+    assert_receive :reconnected
+
+    assert [
+      connect: [opts2],
+      handle_begin: [_, :state],
+      handle_execute_many: [[{%Q{}, [:param], []}], _, :new_state],
+      disconnect: [^err, :newer_state],
+      connect: [opts2]] = A.record(agent)
+  end
+
+  test "execute_many bad return raises DBConnection.Error and stops" do
+    stack = [
+      fn(opts) ->
+        send(opts[:parent], {:hi, self()})
+        Process.link(opts[:parent])
+        {:ok, :state}
+      end,
+      {:ok, :began, :new_state},
+      :oops,
+      {:ok, :state}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self()]
+    {:ok, pool} = P.start_link(opts)
+    assert_receive {:hi, conn}
+
+    Process.flag(:trap_exit, true)
+
+    assert_raise DBConnection.Error, "bad return value: :oops",
+      fn() -> P.execute_many(pool, [{%Q{}, [:param], []}]) end
+
+    assert_receive {:EXIT, ^conn,
+      {%DBConnection.Error{message: "client stopped: " <> _}, [_|_]}}
+
+    assert [
+      {:connect, _},
+      {:handle_begin, [_, :state]},
+      {:handle_execute_many, [[{%Q{}, [:param], []}], _, :new_state]} |
+      _] = A.record(agent)
+  end
+
+  test "execute_many raise raises and stops connection but no log" do
+    stack = [
+      fn(opts) ->
+        send(opts[:parent], {:hi, self()})
+        Process.link(opts[:parent])
+        {:ok, :state}
+      end,
+      {:ok, :began, :new_state},
+      fn(_, _, _) ->
+        raise "oops"
+      end,
+      {:ok, :state}
+      ]
+    {:ok, agent} = A.start_link(stack)
+
+    opts = [agent: agent, parent: self()]
+    {:ok, pool} = P.start_link(opts)
+    assert_receive {:hi, conn}
+
+    Process.flag(:trap_exit, true)
+
+    log = fn(_) -> flunk "logged" end
+    assert_raise RuntimeError, "oops",
+      fn() -> P.execute_many(pool, [{%Q{}, [:param], []}], [log: log]) end
+
+    assert_receive {:EXIT, ^conn,
+      {%DBConnection.Error{message: "client stopped: " <> _}, [_|_]}}
+
+    assert [
+      {:connect, _},
+      {:handle_begin, [_, :state]},
+      {:handle_execute_many, [[{%Q{}, [:param], []}], _, :new_state]} |
+      _] = A.record(agent)
+  end
+end

--- a/integration_test/tests.exs
+++ b/integration_test/tests.exs
@@ -2,6 +2,7 @@ Code.require_file "cases/after_connect_test.exs", __DIR__
 Code.require_file "cases/backoff_test.exs", __DIR__
 Code.require_file "cases/client_test.exs", __DIR__
 Code.require_file "cases/close_test.exs", __DIR__
+Code.require_file "cases/execute_many_test.exs", __DIR__
 Code.require_file "cases/execute_test.exs", __DIR__
 Code.require_file "cases/idle_test.exs", __DIR__
 Code.require_file "cases/prepare_execute_test.exs", __DIR__

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -52,6 +52,14 @@ defmodule TestConnection do
         DBConnection.execute!(pool, query, params, opts2 ++ unquote(opts))
       end
 
+      def execute_many(pool, requests, opts2 \\ []) do
+        DBConnection.execute_many(pool, requests, opts2 ++ unquote(opts))
+      end
+
+      def execute_many!(pool, requests, opts2 \\ []) do
+        DBConnection.execute_many!(pool, requests, opts2 ++ unquote(opts))
+      end
+
       def close(pool, query, opts2 \\ []) do
         DBConnection.close(pool, query, opts2 ++ unquote(opts))
       end
@@ -110,6 +118,10 @@ defmodule TestConnection do
 
   def handle_execute_close(query, params, opts, state) do
     TestAgent.eval(:handle_execute_close, [query, params, opts, state])
+  end
+
+  def handle_execute_many(requests, opts, state) do
+    TestAgent.eval(:handle_execute_many, [requests, opts, state])
   end
 
   def handle_close(query, opts, state) do


### PR DESCRIPTION
Adds an efficient method of executing multiple queries inside a transaction.

* Automatically adds a transaction around the call (disabled with `transaction: false`)
* Executes many queries (pipelined in postgrex's case for 1 round trip)
* Stops executing on first error and just returns the error
* If inside a transaction rolls back the transaction on error
* All decoding delayed until after the transaction is committed (potentially after checking in the connection)
* All logging delayed until after the transaction (potentially after checking in the connection)

This means we can execute any number of queries inside a transaction and not block the connection at all to log or decode. Also in postgrex it would only take 3 round trips, however many queries are executed, when wrapping with a transaction.

The caveat is that queries must be prepared beforehand.

Potential issues:

* Ignores results of successful queries if there is an error
* decode_mapper breaks down as its set for all queries, should the API be extended to set per query options? Would that make this too complicated to use?
* Do we want to commit a transaction we cant decode?

