### PR TITLE
Remove :backoff dependency

### DIFF
--- a/integration_test/cases/backoff_test.exs
+++ b/integration_test/cases/backoff_test.exs
@@ -17,8 +17,7 @@ defmodule BackoffTest do
       end]
     {:ok, agent} = A.start_link(stack)
 
-    opts = [agent: agent, parent: self(), backoff_start: 10,
-            backoff_type: :normal]
+    opts = [agent: agent, parent: self(), backoff_min: 10]
     {:ok, _} = P.start_link(opts)
     assert_receive {:error, conn}
     assert_receive {:hi, ^conn}
@@ -45,8 +44,7 @@ defmodule BackoffTest do
       end]
     {:ok, agent} = A.start_link(stack)
 
-    opts = [agent: agent, parent: self(), backoff_start: 10,
-            backoff_type: :jitter]
+    opts = [agent: agent, parent: self(), backoff_min: 10]
     {:ok, _} = P.start_link(opts)
     assert_receive {:hi1, conn}
     assert_receive {:hi2, ^conn}
@@ -118,8 +116,7 @@ defmodule BackoffTest do
       send(parent, :after_connect)
       Process.exit(self(), :shutdown)
     end
-    opts = [after_connect: after_connect, agent: agent, parent: self(),
-            backoff_type: :normal]
+    opts = [after_connect: after_connect, agent: agent, parent: self()]
     {:ok, _} = P.start_link(opts)
 
     assert_receive :after_connect

--- a/lib/db_connection.ex
+++ b/lib/db_connection.ex
@@ -359,10 +359,11 @@ defmodule DBConnection do
     `DBConnection.Connection`)
     * `:idle_timeout` - The idle timeout to ping the database (default:
     `15_000`)
-    * `:backoff_start` - The first backoff interval (default: `200`)
+    * `:backoff_min` - The minimum backoff interval (default: `200`)
     * `:backoff_max` - The maximum backoff interval (default: `15_000`)
     * `:backoff_type` - The backoff strategy, `:stop` for no backoff and
-    to stop (see `:backoff`, default: `:jitter`)
+    to stop, `:exp` for exponential, `:rand` for random and `:rand_exp` for
+    random exponential (default: `:rand_exp`)
     * `:after_connect` - A function to run on connect using `run/3`, either
     a 1-arity fun, `{module, function, args}` with `DBConnection.t` prepended
     to `args` or `nil` (default: `nil`)

--- a/lib/db_connection/backoff.ex
+++ b/lib/db_connection/backoff.ex
@@ -1,0 +1,117 @@
+defmodule DBConnection.Backoff do
+  @moduledoc false
+
+  alias DBConnection.Backoff
+
+  @default_type :rand_exp
+  @min          200
+  @max          15_000
+
+  defstruct [:type, :min, :max, :state]
+
+  def new(opts) do
+    case Keyword.get(opts, :backoff_type, @default_type) do
+      :stop ->
+        nil
+      type ->
+        {min, max} = min_max(opts)
+        new(type, min, max)
+    end
+  end
+
+  def backoff(%Backoff{type: :rand, min: min, max: max, state: state} = s) do
+    {backoff, state} = rand(state, min, max)
+    {backoff, %Backoff{s | state: state}}
+  end
+  def backoff(%Backoff{type: :exp, min: min, state: nil} = s) do
+    {min, %Backoff{s | state: min}}
+  end
+  def backoff(%Backoff{type: :exp, max: max, state: prev} = s) do
+    require Bitwise
+    next = min(Bitwise.<<<(prev, 1), max)
+    {next, %Backoff{s | state: next}}
+  end
+  def backoff(%Backoff{type: :rand_exp, max: max, state: state} = s) do
+    {prev, lower, rand_state} = state
+    next_min = min(prev, lower)
+    next_max = min(prev * 3, max)
+    {next, rand_state} = rand(rand_state, next_min, next_max)
+    {next, %Backoff{s | state: {next, lower, rand_state}}}
+  end
+
+  def reset(%Backoff{type: :rand} = s), do: s
+  def reset(%Backoff{type: :exp} = s), do: %Backoff{s | state: nil}
+  def reset(%Backoff{type: :rand_exp, min: min, state: state} = s) do
+    {_, lower, rand_state} = state
+    %Backoff{s | state: {min, lower, rand_state}}
+  end
+
+  ## Internal
+
+  defp min_max(opts) do
+    ## TODO: remove :backoff_start in 1.0
+    case {opts[:backoff_min] || opts[:backoff_start], opts[:backoff_max]} do
+      {nil, nil} -> {@min, @max}
+      {nil, max} -> {min(@min, max), max}
+      {min, nil} -> {min, max(min, @max)}
+      {min, max} -> {min, max}
+    end
+  end
+
+  defp new(_, min, _) when not (is_integer(min) and min >= 0) do
+    raise ArgumentError, "minimum #{inspect min} not 0 or a positive integer"
+  end
+  defp new(_, _, max) when not (is_integer(max) and max >= 0) do
+    raise ArgumentError, "maximum #{inspect max} not 0 or a positive integer"
+  end
+  defp new(_, min, max) when min > max do
+    raise ArgumentError, "minimum #{min} is greater than maximum #{max}"
+  end
+  defp new(:rand, min, max) do
+    %Backoff{type: :rand, min: min, max: max, state: seed()}
+  end
+  ## TODO: remove :normal in 1.0
+  defp new(type, min, max) when type in [:normal, :exp] do
+    %Backoff{type: :exp, min: min, max: max, state: nil}
+  end
+  ## TODO: remove :jitter in 1.0
+  defp new(type, min, max) when type in [:jitter, :rand_exp] do
+    lower = max(min, div(max, 3))
+    %Backoff{type: :rand_exp, min: min, max: max, state: {min, lower, seed()}}
+  end
+  defp new(type, _, _) do
+    raise ArgumentError, "unknown type #{inspect type}"
+  end
+
+  defp seed() do
+    case rand_module() do
+      :rand ->
+        {:rand, :rand.seed_s(:exsplus)}
+      :random ->
+        {:random, random_seed()}
+      end
+  end
+
+  defp rand_module() do
+    {:ok, mods} = :application.get_key(:stdlib, :modules)
+    if :rand in mods do
+      :rand
+    else
+      :random
+    end
+  end
+
+  defp random_seed() do
+    {_, sec, micro} = :os.timestamp()
+    hash = :erlang.phash2({self(), make_ref()})
+    case :random.seed(hash, sec, micro) do
+      :undefined -> Process.delete(:random_seed)
+      prev       -> Process.put(:random_seed, prev)
+    end
+  end
+
+  defp rand({mod, state}, min, max) do
+    {int, state} = apply(mod, :uniform_s, [max - min + 1, state])
+    {int + min - 1, {mod, state}}
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -21,13 +21,12 @@ defmodule DBConnection.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :connection, :backoff],
+    [applications: [:logger, :connection],
      mod: {DBConnection.App, []}]
   end
 
   defp deps do
     [{:connection, "~> 1.0.2"},
-     {:backoff, "1.1.1"}, # ~> 1.1.2 requires rebar3/elixir 1.2
      {:poolboy, "~> 1.5", [optional: true]},
      {:sbroker, "~> 0.7", [optional: true]},
      {:earmark, "~> 0.1", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,4 @@
-%{"backoff": {:hex, :backoff, "1.1.1"},
-  "connection": {:hex, :connection, "1.0.2"},
+%{"connection": {:hex, :connection, "1.0.2"},
   "earmark": {:hex, :earmark, "0.1.19"},
   "ex_doc": {:hex, :ex_doc, "0.11.1"},
   "poolboy": {:hex, :poolboy, "1.5.1"},

--- a/test/db_connection/backoff_test.exs
+++ b/test/db_connection/backoff_test.exs
@@ -1,0 +1,107 @@
+defmodule DBConnection.BackoffTest do
+  use ExUnit.Case, async: true
+
+  alias DBConnection.Backoff
+
+  @moduletag backoff_min: 200
+  @moduletag backoff_max: 15_000
+
+  @tag backoff_type: :exp
+  test "exponential backoffs aways in [min, max]", context do
+    backoff = new(context)
+    {delays, _} = backoff(backoff, 20)
+    assert Enum.all?(delays, fn(delay) ->
+      delay >= context[:backoff_min] and delay <= context[:backoff_max]
+    end)
+  end
+
+  @tag backoff_type: :exp
+  test "exponential backoffs double until max", context do
+    backoff = new(context)
+    {delays, _} = backoff(backoff, 20)
+    Enum.reduce(delays, fn(next, prev) ->
+      assert div(next, 2) == prev or next == context[:backoff_max]
+      next
+    end)
+  end
+
+  @tag backoff_type: :exp
+  test "exponential backoffs reset to min", context do
+    backoff = new(context)
+    {[delay | _], backoff} = backoff(backoff, 20)
+    assert delay == context[:backoff_min]
+
+    backoff = Backoff.reset(backoff)
+    {[delay], _} = backoff(backoff, 1)
+    assert delay == context[:backoff_min]
+  end
+
+  @tag backoff_type: :rand
+  test "random backoffs aways in [min, max]", context do
+    backoff = new(context)
+    {delays, _} = backoff(backoff, 20)
+    assert Enum.all?(delays, fn(delay) ->
+      delay >= context[:backoff_min] and delay <= context[:backoff_max]
+    end)
+  end
+
+  @tag backoff_type: :rand
+  test "random backoffs are not all the same value", context do
+    backoff = new(context)
+    {delays, _} = backoff(backoff, 20)
+    ## If the stars align this test could fail ;)
+    refute Enum.all?(delays, &(hd(delays) == &1))
+  end
+
+  @tag backoff_type: :rand
+  test "random backoffs repeat", context do
+    backoff = new(context)
+    assert backoff(backoff, 20) == backoff(backoff, 20)
+  end
+
+  @tag backoff_type: :rand_exp
+  test "random exponential backoffs aways in [min, max]", context do
+    backoff = new(context)
+    {delays, _} = backoff(backoff, 20)
+    assert Enum.all?(delays, fn(delay) ->
+      delay >= context[:backoff_min] and delay <= context[:backoff_max]
+    end)
+  end
+
+  @tag backoff_type: :rand_exp
+  test "random exponential backoffs increase until a third of max", context do
+    backoff = new(context)
+    {delays, _} = backoff(backoff, 20)
+    Enum.reduce(delays, fn(next, prev) ->
+      assert next >= prev or (next >= div(context[:backoff_max], 3))
+      next
+    end)
+  end
+
+  @tag backoff_type: :rand_exp
+  test "random exponential backoffs repeat", context do
+    backoff = new(context)
+    assert backoff(backoff, 20) == backoff(backoff, 20)
+  end
+
+  @tag backoff_type: :rand_exp
+  test "random exponential backoffs reset in [min, min * 3]", context do
+    backoff = new(context)
+    {[delay | _], backoff} = backoff(backoff, 20)
+    assert delay in context[:backoff_min]..(context[:backoff_min]*3)
+
+    backoff = Backoff.reset(backoff)
+    {[delay], _} = backoff(backoff, 1)
+    assert delay in context[:backoff_min]..(context[:backoff_min]*3)
+  end
+
+  ## Helpers
+
+  def new(context) do
+    Backoff.new(Enum.into(context, []))
+  end
+
+  defp backoff(backoff, n) do
+    Enum.map_reduce(1..n, backoff, fn(_, acc) -> Backoff.backoff(acc) end)
+  end
+end

--- a/test/test_support.exs
+++ b/test/test_support.exs
@@ -3,7 +3,8 @@ defmodule TestConnection do
   defmacro __using__(opts) do
     quote do
       def start_link(opts2) do
-        TestConnection.start_link(unquote(opts) ++ opts2)
+        defaults = [backoff_type: :exp]
+        TestConnection.start_link(opts2 ++ unquote(opts) ++ defaults)
       end
 
       def query(pool, query, params, opts2 \\ []) do


### PR DESCRIPTION
Closes #19.

The backoff API is made slightly clearer (what is `:normal`?), a new backoff type has been added (`:rand`) and there are TODOs to remove backwards compatible code in 1.0.

However perhaps we should move this to Connection as it is likely to be useful there?