### PR TITLE
Introduce ownership_timeout

### DIFF
--- a/lib/db_connection/ownership.ex
+++ b/lib/db_connection/ownership.ex
@@ -15,6 +15,8 @@ defmodule DBConnection.Ownership do
       implicitly. `{:shared, owner}` mode is also supported so
       processes are allowed on demand. On all cases, checkins are
       explicit via `ownership_checkin/2`. Defaults to `:auto`.
+    * `:ownership_timeout` - The maximum time that a process is allowed to own
+      a connection, default `15_000`.
 
   If the `:ownership_pool` has an atom name given in the `:name` option,
   an ETS table will be created and automatically used for lookups whenever


### PR DESCRIPTION
Closes #22.

The fix is not quite the same as suggested by #22. We don't want the pool to timeout the connection and disconnect it but the owner process to continue handing out the dead connection with divergent state from the pool. Therefore we pass `timeout: :infinity` to the pool and do a timeout in the owner process. This will allow people to set `ownership_timeout: :infinity` to play with sandboxes in dev/shell.